### PR TITLE
Adds the lightning.qubit card

### DIFF
--- a/jinja/plugins.html
+++ b/jinja/plugins.html
@@ -31,22 +31,33 @@
                 </a>
             </div>
             <div class="card plugin-card">
+                <a href="https://pennylane.readthedocs.io/en/stable/code/api/pennylane.plugins.default_qubit_tf.DefaultQubitTF.html">
+                    <h4 class="card-header juicy-peach-gradient">default.qubit.tf</h4>
+                    <div class="card-body">
+                        <p class="card-text">
+                            A state-vector qubit simulator written using TensorFlow and supporting classical backpropagation. <br><br>A good choice when the number of parameters to be optimized is large.
+                        </p>
+                    </div>
+                </a>
+            </div>
+            <div class="card plugin-card">
+                <a href="https://pennylane-lightning.readthedocs.io">
+                    <h4 class="card-header juicy-peach-gradient">lightning.qubit (beta)</h4>
+                    <div class="card-body">
+                        <p class="card-text">
+                            A state-vector qubit simulator written with a C++ backend.
+                            <br><br>A good choice if you want to run faster than default.qubit.
+                        </p>
+                    </div>
+                </a>
+            </div>
+            <div class="card plugin-card">
                 <a href="https://pennylane.readthedocs.io/en/stable/code/api/pennylane.plugins.default_gaussian.DefaultGaussian.html">
                     <h4 class="card-header juicy-peach-gradient">default.gaussian</h4>
                     <div class="card-body">
                         <p class="card-text">
                             A simple quantum photonic simulator written in Python.
                             <br><br>A good choice for optimizating photonic systems.
-                        </p>
-                    </div>
-                </a>
-            </div>
-            <div class="card plugin-card">
-                <a href="https://pennylane.readthedocs.io/en/stable/code/api/pennylane.plugins.default_qubit_tf.DefaultQubitTF.html">
-                    <h4 class="card-header juicy-peach-gradient">default.qubit.tf</h4>
-                    <div class="card-body">
-                        <p class="card-text">
-                            A state-vector qubit simulator written using TensorFlow and supporting classical backpropagation. <br><br>A good choice when the number of parameters to be optimized is large.
                         </p>
                     </div>
                 </a>

--- a/jinja/plugins.html
+++ b/jinja/plugins.html
@@ -57,7 +57,7 @@
                     <div class="card-body">
                         <p class="card-text">
                             A simple quantum photonic simulator written in Python.
-                            <br><br>A good choice for optimizating photonic systems.
+                            <br><br>A good choice for optimizing photonic systems.
                         </p>
                     </div>
                 </a>


### PR DESCRIPTION
Adds a device card for the upcoming release of `lightning.qubit`.
Here is where the card links to: https://pennylane-lightning.readthedocs.io/en/latest/

(note, the order of the cards was also updated to bring all the qubit ones together)

![image](https://user-images.githubusercontent.com/49409390/90038673-b13ba200-dc93-11ea-82ef-3fb2fd41685c.png)
