### PR TITLE
Remove beta tag from Lightning-Qubit

### DIFF
--- a/jinja/plugins.html
+++ b/jinja/plugins.html
@@ -56,7 +56,7 @@
         <div class="card-deck mt-5">
             <div class="card plugin-card">
                 <a href="https://pennylane-lightning.readthedocs.io">
-                    <h4 class="card-header juicy-peach-gradient">lightning.qubit (beta)</h4>
+                    <h4 class="card-header juicy-peach-gradient">lightning.qubit</h4>
                     <div class="card-body">
                         <p class="card-text">
                             A fast state-vector qubit simulator written with a C++ backend.


### PR DESCRIPTION
With the `0.18.0` release of Lightning-Qubit, we should be confident enough to bring it out of "beta" mode.