### PR TITLE
Update lightning.qubit doc link

### DIFF
--- a/jinja/plugins.html
+++ b/jinja/plugins.html
@@ -31,7 +31,7 @@
                 </a>
             </div>
             <div class="card plugin-card">
-                <a href="https://pennylane-lightning.readthedocs.io">
+                <a href="https://docs.pennylane.ai/projects/lightning/en/stable/">
                     <h4 class="card-header juicy-peach-gradient">lightning.qubit</h4>
                     <div class="card-body">
                         <p class="card-text">


### PR DESCRIPTION
It seems like the link to `lightning.qubit` does not work. I updated it to follow one in Lightning GH.