### PR TITLE
pin jax and jaxlib version in installation doc

### DIFF
--- a/jinja/install.html
+++ b/jinja/install.html
@@ -128,7 +128,7 @@ pip install -e .
             </label>
             <label class="nav-item">
                 <a class="nav-link" id="jax">
-                    <input type="checkbox" pip="jax jaxlib">
+                    <input type="checkbox" pip="jax==0.4.3 jaxlib==0.4.3">
                     <span>JAX</span>
                 </a>
             </label>


### PR DESCRIPTION
PennyLane is not compatible with the latest jax, and if the users follow our docs, they will get a version of jax that doesn't work with PennyLane (unless they already have 0.4.0<theirs<0.4.4 and they don't specify -U)

The risk here is that we forget about it and don't update this doc once we support higher jax versions